### PR TITLE
Allow setting of where results are placed

### DIFF
--- a/phantomjs/runner.js
+++ b/phantomjs/runner.js
@@ -65,7 +65,7 @@ phantomcss.init({
   },
   fileNameGetter: function(root,filename){
 
-        var name = phantomcss.pathToTest + 'baseline/' + filename;
+        var name = phantomcss.pathToTest + args.results + '/' + filename;
         if(fs.isFile(name+'.png')){
             return name +'.diff.png';
         } else {

--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
         var options = this.options({
             rootUrl: false,
             screenshots: 'screenshots',
-            results: 'results',
+            results: 'baseline',
             viewportSize: [1280, 800],
             mismatchTolerance: 0.05,
             waitTimeout: 5000, // Set timeout to wait before throwing an exception


### PR DESCRIPTION
Results directive determines folder in tests dir to place baselines and screenshot test results.

Settings results in Gruntfile.js to baselines, will place results in the baselines dir as before this fix.