### PR TITLE
Cleanup files

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,0 +1,64 @@
+{
+	"disallowSpacesInNamedFunctionExpression": {
+		"beforeOpeningRoundBrace": true
+	},
+	"disallowSpacesInFunctionExpression": {
+		"beforeOpeningRoundBrace": true
+	},
+	"disallowSpacesInAnonymousFunctionExpression": {
+		"beforeOpeningRoundBrace": true
+	},
+	"disallowSpacesInFunctionDeclaration": {
+		"beforeOpeningRoundBrace": true
+	},
+	"disallowEmptyBlocks": true,
+	"disallowSpacesInsideArrayBrackets": true,
+	"disallowSpacesInsideParentheses": true,
+	"disallowQuotedKeysInObjects": true,
+	"disallowSpaceAfterObjectKeys": true,
+	"disallowSpaceAfterPrefixUnaryOperators": true,
+	"disallowSpaceBeforePostfixUnaryOperators": true,
+	"disallowSpaceBeforeBinaryOperators": [
+		","
+	],
+	"disallowMixedSpacesAndTabs": true,
+	"disallowTrailingWhitespace": true,
+	"disallowTrailingComma": true,
+	"disallowYodaConditions": true,
+	"disallowKeywords": [ "with" ],
+	"disallowMultipleLineBreaks": true,
+	"disallowMultipleVarDecl": true,
+	"requireSpaceBeforeBlockStatements": true,
+	"requireParenthesesAroundIIFE": true,
+	"requireSpacesInConditionalExpression": true,
+	"requireBlocksOnNewline": 1,
+	"requireCommaBeforeLineBreak": true,
+	"requireSpaceBeforeBinaryOperators": true,
+	"requireSpaceAfterBinaryOperators": true,
+	"requireCamelCaseOrUpperCaseIdentifiers": true,
+	"requireLineFeedAtFileEnd": true,
+	"requireCapitalizedConstructors": true,
+	"requireDotNotation": true,
+	"requireSpacesInForStatement": true,
+	"requireSpaceBetweenArguments": true,
+	"requireCurlyBraces": [
+		"do"
+	],
+	"requireSpaceAfterKeywords": [
+		"if",
+		"else",
+		"for",
+		"while",
+		"do",
+		"switch",
+		"case",
+		"return",
+		"try",
+		"catch",
+		"typeof"
+	],
+	"safeContextKeyword": "_this",
+	"validateLineBreaks": "LF",
+	"validateQuoteMarks": "'",
+	"validateIndentation": "\t"
+}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Or add the following line to your `package.json`:
 Then, once the plugin has been installed via `npm install`, it may be enabled inside your Gruntfile with this line of JavaScript:
 
 ```js
-grunt.loadNpmTasks('grunt-phantomcss');
+grunt.loadNpmTasks('@micahgodbolt/grunt-phantomcss');
 ```
 
 ## The "phantomcss" task

--- a/phantomjs/runner.js
+++ b/phantomjs/runner.js
@@ -70,7 +70,7 @@ phantomcss.init({
     } else {
       return name + '.png';
     }
-  },
+  }
 });
 
 casper.start();

--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -57,7 +57,7 @@ module.exports = function(grunt) {
 
       // Delete all of 'em
       diffScreenshots.forEach(function(filepath) {
-        grunt.file.delete(filepath);
+        grunt.file.delete(filepath, { force: true });
       });
     };
 
@@ -69,7 +69,7 @@ module.exports = function(grunt) {
 
       // Delete all of 'em
       diffScreenshots.forEach(function(filepath) {
-        grunt.file.delete(filepath);
+        grunt.file.delete(filepath, { force: true });
       });
     };
 

--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -48,27 +48,14 @@ module.exports = function(grunt) {
     // Create a temporary file for message passing between the task and PhantomJS
     var tempFile = new tmp.File();
 
-    var deleteDiffScreenshots = function(folderpath) {
+    var deleteScreenshots = function(pattern) {
       // Find diff/fail files
-      var diffScreenshots = grunt.file.expand([
-        path.join(folderpath + '/' + options.screenshots, '*diff.png'),
-        path.join(folderpath + '/' + options.screenshots, '*fail.png'),
+      var screenshots = grunt.file.expand([
+        path.join(options.screenshots, pattern)
       ]);
 
       // Delete all of 'em
-      diffScreenshots.forEach(function(filepath) {
-        grunt.file.delete(filepath, { force: true });
-      });
-    };
-
-    var deleteDiffResults = function(folderpath) {
-      // Find diff/fail files
-      var diffScreenshots = grunt.file.expand([
-        path.join(folderpath, options.results),
-      ]);
-
-      // Delete all of 'em
-      diffScreenshots.forEach(function(filepath) {
+      screenshots.forEach(function(filepath) {
         grunt.file.delete(filepath, { force: true });
       });
     };
@@ -76,24 +63,7 @@ module.exports = function(grunt) {
     var cleanup = function(error) {
       // Remove temporary file
       tempFile.unlink();
-
-      options.testFolder.forEach(function(folderpath) {
-        // Create the output directory
-        grunt.file.mkdir(folderpath + '/' + options.results);
-
-        // Copy fixtures, diffs, and failure images to the results directory
-        var allScreenshots = grunt.file.expand(path.join(folderpath + '/' + options.screenshots, '**.png'));
-
-        allScreenshots.forEach(function(filepath) {
-          grunt.file.copy(filepath, path.join(
-              folderpath + '/' + options.results,
-              path.basename(filepath)
-          ));
-        });
-
-        deleteDiffScreenshots(folderpath);
-      });
-
+      deleteScreenshots('*diff.png');
       done(error || failureCount === 0);
     };
 
@@ -180,8 +150,8 @@ module.exports = function(grunt) {
     // Remove old diff screenshots
 
     options.testFolder.forEach(function(folderpath) {
-      deleteDiffScreenshots(folderpath);
-      deleteDiffResults(folderpath);
+      deleteScreenshots('*diff.png');
+      deleteScreenshots('*fail.png');
     });
 
     // Start watching for messages
@@ -190,8 +160,8 @@ module.exports = function(grunt) {
     grunt.util.spawn({
       cmd: phantomBinaryPath,
       args: [
-        runnerPath,
-        JSON.stringify(options),
+      runnerPath,
+      JSON.stringify(options)
       ],
       opts: {
         cwd: cwd,


### PR DESCRIPTION
It wasn't deleting .diff files and old .fail screenshots. Now the screenshots folder will only have the original screenshots and the screenshots of failing tests.

options.screenshots will take full path relative to the root folder of the project.
        phantomcss: {
            options: {
                screenshots: 'autotest/ui-tests/reference-screenshots',
