### PR TITLE
Adding phantomjsArgs array to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ grunt.initConfig({
         viewportSize: [1280, 800],
         mismatchTolerance: 0.05,
         rootUrl: 'http://localhost:3000/' // Optional
+        phantomjsArgs: [
+          // optional, array of phantomJS CLI options
+        ]
       },
       src: [
         'test/visual/**/*.js'
@@ -99,6 +102,12 @@ Type: `String`
 Default: ``
 
 Optional parameter passed to testfiles for prepending to relative URL's. Useful when testing against multiple environments.
+
+#### options.phantomjsArgs
+Type: `Array`
+Default: `[]`
+
+Optional array of CLI arguments passed when running phantomJS. See [PhantomJS Command-line Options](http://phantomjs.org/api/command-line.html) for details.
 
 
 ### Usage Examples

--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -29,7 +29,8 @@ module.exports = function(grunt) {
       viewportSize: [1280, 800],
       mismatchTolerance: 0.05,
       waitTimeout: 5000, // Set timeout to wait before throwing an exception
-      logLevel: 'warning' // debug | info | warning | error
+      logLevel: 'warning', // debug | info | warning | error
+      phantomjsArgs: []
     });
 
     // Timeout ID for message checking loop
@@ -184,15 +185,17 @@ module.exports = function(grunt) {
       deleteDiffResults(folderpath);
     });
 
+    var runnerArgs = options.phantomjsArgs.concat([
+      runnerPath,
+      JSON.stringify(options),
+    ]);
+
     // Start watching for messages
     checkForMessages();
 
     grunt.util.spawn({
       cmd: phantomBinaryPath,
-      args: [
-        runnerPath,
-        JSON.stringify(options),
-      ],
+      args: runnerArgs,
       opts: {
         cwd: cwd,
         stdio: 'inherit'


### PR DESCRIPTION
The current setup does not allow passing arguments to phantomJS, which is required to run against websites which block SSLv3 connections (PhantomJS defaults to SSLv3).

This can now be achieved by through a phantomjsArgs option in the Gruntfile.
The common issue of needing to run against something other than SSLv3 becomes just this:

``` javascript
phantomcss: {
    options: {
        [...]
        logLevel: 'warning', // [debug, info, warning, error]
        phantomjsArgs: [
            '--ssl-protocol=tlsv1',
            '--ignore-ssl-errors=true',
        ]
    }
}
```
