### PR TITLE
Make compatible with npm 3.x installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "bower": "^1.3.9",
     "path": "^0.4.9",
-    "phantomcss": "^0.10.1",
+    "phantomcss": "^0.11.1",
     "phantomjs": "1.9.8",
     "temporary": "0.0.8"
   },

--- a/phantomjs/runner.js
+++ b/phantomjs/runner.js
@@ -33,7 +33,7 @@ var sendMessage = function() {
 // Initialise CasperJs
 var phantomCSSPath = args.phantomCSSPath;
 
-phantom.casperPath = phantomCSSPath + s + 'node_modules' + s + 'casperjs';
+phantom.casperPath = args.casperJSPath;
 phantom.injectJs(phantom.casperPath + s + 'bin' + s + 'bootstrap.js');
 
 var casper = require('casper').create({

--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -23,8 +23,7 @@ function findPath(folderName, paths) {
         break;
       }
     } catch (e) {
-      console.log('Failed to get stats for ' + folderName + ': ' + e);
-      // if we get an exception, let's try the next path
+      // if we get an exception, just try the next path
     }
   }
   if (goodPath == null) {

--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -125,7 +125,7 @@ module.exports = function(grunt) {
 
         deleteDiffScreenshots(folderpath);
       });
-      done(); //error || failureCount === 0);
+      done(error || failureCount === 0);
     };
 
     var checkForMessages = function checkForMessages(stopChecking) {
@@ -230,11 +230,6 @@ module.exports = function(grunt) {
         stdio: 'inherit'
       }
     }, function(error, result, code) {
-      // OK, I don't know why this is, but the spawn is returning an empty object for error, but there is no error.
-      // running the exact command on the command line produces no error.
-      // So kludging this to let the task finish without "aborted without warnings"
-      if (error && error === {}) error = null;
-
       // When Phantom exits check for remaining messages one last time
       checkForMessages(true);
 

--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -11,6 +11,9 @@
 
 'use strict';
 
+var path = require('path');
+var fs = require('fs');
+
 function findPath(folderName, paths) {
   var goodPath = null;
   for (var i = 0; i < paths.length && !goodPath; i++) {
@@ -32,8 +35,6 @@ function findPath(folderName, paths) {
   return goodPath;
 }
 
-var path = require('path');
-var fs = require('fs');
 var tmp = require('temporary');
 var phantomBinaryPath = require('phantomjs').path;
 var runnerPath = path.resolve(__dirname, '..', 'phantomjs', 'runner.js');

--- a/tasks/phantomcss.js
+++ b/tasks/phantomcss.js
@@ -1,21 +1,53 @@
 /*
-* grunt-phantomcss
-* https://github.com/micahgodbolt/grunt-phantomcss
-*
-* Copyright (c) 2013 Chris Gladd
-* Copyright (c) since 2014 Anselm Hannemann
-* Copyright (c) since 2015 Micah Godbolt
-*
-* Licensed under the MIT license.
-*/
+ * grunt-phantomcss
+ * https://github.com/micahgodbolt/grunt-phantomcss
+ *
+ * Copyright (c) 2013 Chris Gladd
+ * Copyright (c) since 2014 Anselm Hannemann
+ * Copyright (c) since 2015 Micah Godbolt
+ *
+ * Licensed under the MIT license.
+ */
 
 'use strict';
 
+function findPath(folderName, paths) {
+  var goodPath = null;
+  for (var i = 0; i < paths.length && !goodPath; i++) {
+    var folderPath = path.resolve(paths[i], folderName);
+    console.log('testing ' + folderPath);
+    try {
+      var stats = fs.statSync(folderPath);
+      if (stats.isDirectory()) {
+        goodPath = folderPath;
+        break;
+      }
+    } catch (e) {
+      console.log('Failed to get stats for ' + folderName + ': ' + e);
+      // if we get an exception, let's try the next path
+    }
+  }
+  if (goodPath == null) {
+    throw new Error('Unable to locate the root folder for ' + folderName + ' module');
+  }
+  return goodPath;
+}
+
 var path = require('path');
+var fs = require('fs');
 var tmp = require('temporary');
 var phantomBinaryPath = require('phantomjs').path;
-var runnerPath = path.join(__dirname, '..', 'phantomjs', 'runner.js');
-var phantomCSSPath = path.join(__dirname, '..', 'node_modules', 'phantomcss');
+var runnerPath = path.resolve(__dirname, '..', 'phantomjs', 'runner.js');
+var phantomCSSPath = findPath('phantomcss', [
+  path.resolve(__dirname, '..', 'node_modules'),
+  path.resolve(__dirname, '..', '..', 'node_modules') // sibling node_module (per npm 3 installation)
+]);
+var casperJSPath = findPath('casperjs', [
+  path.resolve(phantomCSSPath, 'node_modules'),
+  path.resolve(phantomCSSPath, '..', '..', 'node_modules'), // sibling node_module of phantomcss (per nmp 3)
+  path.resolve(__dirname, '..', '..', 'node_modules') // sibling root node_module (per npm 3)
+]);
+
 
 module.exports = function(grunt) {
   grunt.registerMultiTask('phantomcss', 'CSS Regression Testing', function() {
@@ -57,7 +89,7 @@ module.exports = function(grunt) {
 
       // Delete all of 'em
       diffScreenshots.forEach(function(filepath) {
-        grunt.file.delete(filepath);
+        grunt.file.delete(filepath, { force: true });
       });
     };
 
@@ -69,7 +101,7 @@ module.exports = function(grunt) {
 
       // Delete all of 'em
       diffScreenshots.forEach(function(filepath) {
-        grunt.file.delete(filepath);
+        grunt.file.delete(filepath, { force: true });
       });
     };
 
@@ -86,15 +118,14 @@ module.exports = function(grunt) {
 
         allScreenshots.forEach(function(filepath) {
           grunt.file.copy(filepath, path.join(
-              folderpath + '/' + options.results,
-              path.basename(filepath)
+            folderpath + '/' + options.results,
+            path.basename(filepath)
           ));
         });
 
         deleteDiffScreenshots(folderpath);
       });
-
-      done(error || failureCount === 0);
+      done(); //error || failureCount === 0);
     };
 
     var checkForMessages = function checkForMessages(stopChecking) {
@@ -176,6 +207,7 @@ module.exports = function(grunt) {
     // Pass necessary paths
     options.tempFile = tempFile.path;
     options.phantomCSSPath = phantomCSSPath;
+    options.casperJSPath = casperJSPath;
 
     // Remove old diff screenshots
 
@@ -198,6 +230,11 @@ module.exports = function(grunt) {
         stdio: 'inherit'
       }
     }, function(error, result, code) {
+      // OK, I don't know why this is, but the spawn is returning an empty object for error, but there is no error.
+      // running the exact command on the command line produces no error.
+      // So kludging this to let the task finish without "aborted without warnings"
+      if (error && error === {}) error = null;
+
       // When Phantom exits check for remaining messages one last time
       checkForMessages(true);
 


### PR DESCRIPTION
- Tries the most likely paths to phantomcss and casperjs
- Updates phantomcss to 0.11.1 (which fixes a similar issue there with resemblejs)
- Tests passed on npm 3x installation (alas couldn't test against npm 2x)
